### PR TITLE
Fix Type Output Issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
   "compilerOptions": {
     "types": ["node", "vite/client"],
     // other options
-    "target": "es6",
-    "module": "commonjs",
+    "target": "ES6",
+    "module": "ESNext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
     dts({
       entryRoot: path.resolve(__dirname, 'src'),
       include: ['src'],
-      tsconfigPath: path.resolve(__dirname, 'tsconfig.json'),
+      exclude: ['src/main.tsx', 'src/App.tsx'],
+      tsconfigPath: path.resolve(__dirname, 'tsconfig.app.json'),
     }),
   ],
   build: {


### PR DESCRIPTION
Updates the tsconfigPath filname to point to the `tsconfig.app.json` file, this was preventing the `index.d.ts` file from being generated when running the build.